### PR TITLE
Resolve home metacharacter in `bundlerPath`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 lib
+node_modules/

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   let applyConfiguration = (_config: solargraph.Configuration) => {
     _config.commandPath = config.commandPath || 'solargraph'
     _config.useBundler = config.useBundler || false
-    _config.bundlerPath = config.bundlerPath || 'bundle'
+    _config.bundlerPath = config.bundlerPath?.replace('~', process.env.HOME) || 'bundle'
     _config.viewsPath = context.extensionPath + '/views'
     _config.withSnippets = config.withSnippets || false
     _config.workspace = workspace.rootPath || null


### PR DESCRIPTION
This resolution allows us to use paths like the following in
`coc-settings.json`

```json
{
  "solargraph.bundlerPath": "~/.gem/ruby/2.6.6/bin/bundle",
}
```

Making the setting generic enough to include it in git.

---

As an unrelated update, I've added `node_modules/` to `.gitignore` in
order to avoid diffs while developing the extension.