### PR TITLE
"solargraph.commandPath" including "~" may not work properly.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export async function activate(context: ExtensionContext): Promise<void> {
   if (enable === false) return
 
   let applyConfiguration = (_config: solargraph.Configuration) => {
-    _config.commandPath = config.commandPath || 'solargraph'
+    _config.commandPath = config.commandPath?.replace('~', process.env.HOME) || 'solargraph'
     _config.useBundler = config.useBundler || false
     _config.bundlerPath = config.bundlerPath?.replace('~', process.env.HOME) || 'bundle'
     _config.viewsPath = context.extensionPath + '/views'


### PR DESCRIPTION
## What happened.

For example, specifying `"solargraph.commandPath": "~/.rbenv/shims/solargraph"` does not work properly.
I got this error message in my neovim...
> [coc.nvim] Failed to start Solargraph: zsh:1: no such file or directory: ~/.rbenv/shims/solargraph

### my coc-settings.json

```
# this is my coc-settings.json
{
    "suggest.autoTrigger": "trigger",
    "suggest.noselect": true,
    "suggest.preferCompleteThanJumpPlaceholder": true,
    "languageserver": {
        "clangd": {
            "command": "clangd",
            "args": ["--background-index"],
            "rootPatterns": ["compile_flags.txt", "compile_commands.json", ".vim/", ".git/", ".hg/"],
            "filetypes": ["c", "cpp", "objc", "objcpp"]
        },
        "dockerfile": {
            "command": "docker-langserver",
            "filetypes": ["dockerfile"],
            "args": ["--stdio"]
        },
        "haskell": {
            "command": "hie-wrapper",
            "rootPatterns": [".stack.yaml", "cabal.config", "package.yaml"],
            "filetypes": ["hs", "lhs", "haskell"],
            "initializationOptions": {
                "languageServerHaskell": {
                    "hlintOn": true
                }
            }
        },
    },
    "python.jediEnabled": false,

    "//solargraph.useBundler": true,
    "solargraph.bundlerPath": "~/.rbenv/shims/bundle",
    "solargraph.commandPath": "~/.rbenv/shims/solargraph"
}
```

## What is the problem.
I think may be the `~` in `"solargraph.commandPath"` should be replaced as `process.env.HOME` as same as `"solargraph.bundlerPath"`.
See L.13.
https://github.com/neoclide/coc-solargraph/blob/3ee67401bedef9ffadf10408ee94b42ae7e85941/src/index.ts#L13-L15

## Solution
Set `solargraph.commandPath` in the same way as `solargraph.bundlerPath`.
